### PR TITLE
OCR corrections

### DIFF
--- a/05_banquet.md
+++ b/05_banquet.md
@@ -2,15 +2,13 @@ BANQUET
 
     
 The battalion will give a banquet
-to tie football team on January 14,
-1911, as an appreciaton of the work
+to the football team on January 14,
+1910, as an appreciaton of the work
 that they have done during the past
 season. Many toasts will be given,
-including those to football, the out
-look and prospects for next year.
+including those to football, the outlook and prospects for next year.
 
     
-The Rossburg Flub lias ar
-ranged to give dances, during 1910
-on the following dates: January 21.
+The Rossburg Club has arranged to give dances, during 1910
+on the following dates: January 21,
 February 12, and April 2.


### PR DESCRIPTION
Corrected OCR errors (such as tie to the, 1911 to 1910, flub to club, and replacing a period with a comma).