### PR TITLE
Update 02_a_banquet_at_berwin.md

### DIFF
--- a/02_a_banquet_at_berwin.md
+++ b/02_a_banquet_at_berwin.md
@@ -3,8 +3,8 @@ A BANQUET AT BERWYN
     
 Mr. Middleton entertained his
 large Sunday School class at a ban
-quet on Friday, December 10, 1900.
-A large number of M. A. ('. Cadets
+quet on Friday, December 10, 1909.
+A large number of M. A. C. Cadets
 are members of the class and were
 present. A fine turkey dinner was
 served, after which Mr. Middleton


### PR DESCRIPTION
2 errors corrected. 1900 revised to read "1909" and acronym adjusted to "C."